### PR TITLE
Run autodiscover from AppConfig

### DIFF
--- a/exampleapp/__init__.py
+++ b/exampleapp/__init__.py
@@ -1,8 +1,1 @@
-from __future__ import print_function
-from periodically.decorators import *
 
-@every(minutes=1)
-@hourly()
-@hourly() # This repetition should have no effect.
-def task1():
-    print('RUNNING exampleapp.task1')

--- a/exampleapp/periodictasks.py
+++ b/exampleapp/periodictasks.py
@@ -3,6 +3,13 @@ from periodically.decorators import *
 from periodically import register
 from datetime import timedelta
 
+ 
+@every(minutes=1)
+@hourly()
+@hourly() # This repetition should have no effect.
+def task1():
+    print('RUNNING exampleapp.task1') 
+
 
 @every(minutes=1)
 def task2():

--- a/periodically/__init__.py
+++ b/periodically/__init__.py
@@ -3,6 +3,9 @@ from .tasks import PeriodicTask
 from .utils import get_scheduler_backend_class
 
 
+default_app_config = 'periodically.apps.PeriodicallyConfig'
+
+
 # Based on django's admin app's autodiscover.
 def autodiscover():
     """

--- a/periodically/apps.py
+++ b/periodically/apps.py
@@ -1,0 +1,13 @@
+from __future__ import \
+    unicode_literals, print_function, division, absolute_import
+
+from django.apps import AppConfig
+
+from periodically import autodiscover
+
+
+class PeriodicallyConfig(AppConfig):
+    name = 'periodically'
+
+    def ready(self):
+        autodiscover()


### PR DESCRIPTION
Django initialization was failing with Django 1.9 with `exampleapp` app, this fixes it.
Also, now automatically calling `autodiscover()` in a way compatible with Django 1.7+ (and mandatory in 1.9)
